### PR TITLE
Stop `wsrun` prefixing output, because it messes with the Jest output.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "start": "yarn workspace @prodo/snoopy-cli start",
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
-    "test": "wsrun --exclude-missing --serial test",
-    "lint": "wsrun --exclude-missing --serial lint"
+    "test": "wsrun --exclude-missing --serial --no-prefix test",
+    "lint": "wsrun --exclude-missing --serial --no-prefix lint"
   },
   "workspaces": [
     "packages/*",


### PR DESCRIPTION
It's not necessary when running serially anyway.