### PR TITLE
Server: sort generated imports by path alphabetically

### DIFF
--- a/packages/server/src/generate.ts
+++ b/packages/server/src/generate.ts
@@ -15,6 +15,7 @@ export const generateComponentsFileContents = async (
       id: `Component${componentCounter++}`,
     })),
   }));
+
   let themeCounter = 0;
   const themeFiles = imports.themeFiles.map(file => ({
     ...file,
@@ -30,6 +31,7 @@ export const generateComponentsFileContents = async (
       namedImports: Array<{from: string; to: string}>;
     };
   } = {};
+
   componentFiles.concat(themeFiles).forEach(({filepath, fileExports}) => {
     if (importsByFile[filepath] == null) {
       importsByFile[filepath] = {
@@ -49,6 +51,7 @@ export const generateComponentsFileContents = async (
   });
 
   const importLines = Object.keys(importsByFile)
+    .sort()
     .map(filepath => {
       const {defaultImport, namedImports} = importsByFile[filepath];
       return `import ${[

--- a/packages/server/test/__snapshots__/generate.test.ts.snap
+++ b/packages/server/test/__snapshots__/generate.test.ts.snap
@@ -2,17 +2,17 @@
 
 exports[`generateComponentsFileContents snapshot test 1`] = `
 "import {Button as Component0} from \\"example\\";
-import {Button as Component1} from \\"example/javascript.jsx\\";
-import {Button as Component2, theme as Theme0} from \\"example/mixed.tsx\\";
-import {Button as Component3} from \\"example/typescript.tsx\\";
 import Component4 from \\"example/components/DefaultExport.tsx\\";
 import {Button2 as Component5} from \\"example/components/Mixed.tsx\\";
 import Component8, {Button as Component6, Button2 as Component7} from \\"example/components/MultipleExports.tsx\\";
 import {Button as Component9} from \\"example/components/NamedExport.tsx\\";
+import {Button as Component1} from \\"example/javascript.jsx\\";
+import {Button as Component2, theme as Theme0} from \\"example/mixed.tsx\\";
 import Theme1 from \\"example/themes/default-export.ts\\";
 import {theme2 as Theme2} from \\"example/themes/mixed.ts\\";
 import Theme5, {theme as Theme3, theme2 as Theme4} from \\"example/themes/multiple-exports.ts\\";
 import {theme as Theme6} from \\"example/themes/named-export.ts\\";
+import {Button as Component3} from \\"example/typescript.tsx\\";
 
 import * as React from \\"react\\";
 import * as ReactDOM from \\"react-dom\\";


### PR DESCRIPTION
We are looping over Object.keys to generate the component/theme imports. However, property order is not guaranteed, so the snapshot test was occasionally failing. This PR sorts the paths before mapping over them.