### PR TITLE
Disable parcel autoinstall

### DIFF
--- a/packages/server/src/bundler.ts
+++ b/packages/server/src/bundler.ts
@@ -35,7 +35,7 @@ export default (
     hmr: true,
     detailedReport: false,
     bundleNodeModules: true,
-    auotInstall: false,
+    autoInstall: false,
     ...options,
   };
 

--- a/packages/server/src/bundler.ts
+++ b/packages/server/src/bundler.ts
@@ -15,7 +15,7 @@ export default (
     searchDir: string;
     componentsFile: string;
   },
-  options: Bundler.ParcelOptions = {},
+  options: any,
 ) => {
   const entryFile = path.join(clientDir, "public", "index.html");
 
@@ -35,6 +35,7 @@ export default (
     hmr: true,
     detailedReport: false,
     bundleNodeModules: true,
+    auotInstall: false,
     ...options,
   };
 

--- a/packages/server/src/bundler.ts
+++ b/packages/server/src/bundler.ts
@@ -15,7 +15,7 @@ export default (
     searchDir: string;
     componentsFile: string;
   },
-  options: any,
+  options?: any,
 ) => {
   const entryFile = path.join(clientDir, "public", "index.html");
 


### PR DESCRIPTION
Parcel will by default install any missing dependencies if it can't find any. This is pretty annoying and I've even noticed it delete the content of `package.json`. There is an option to disable this, which is what this PR does. However, the @types/parcel-bundler do not include `autoInstall` in the options interface, but it is used in the source, https://github.com/parcel-bundler/parcel/blob/master/packages/core/parcel-bundler/src/Bundler.js#L144.