### PR TITLE
Server: use http://localhost:${port} in server start message

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -76,7 +76,9 @@ export const start = async (
   const listen = (portNumber: number) => {
     app
       .listen(portNumber, () => {
-        process.stdout.write(`Server is running on port ${portNumber}.\n`);
+        process.stdout.write(
+          `Server is running at http://localhost:${portNumber}.\n`,
+        );
       })
       .on("error", e => {
         if (portNumber - startingPort > portTriesLimit) {


### PR DESCRIPTION
use `http://localhost:${port}` in server start message so that it is clickable in some terminals.

<img width="358" alt="image" src="https://user-images.githubusercontent.com/3044853/57771889-fd540b80-770b-11e9-96a2-6ed8e071415d.png">

^ I am cmd+hovering over the link in the above image