### PR TITLE
Use port instead of startingPort

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -89,7 +89,7 @@ export const start = async (
         );
       })
       .on("error", e => {
-        if (portNumber - startingPort > portTriesLimit) {
+        if (portNumber - port > portTriesLimit) {
           process.stdout.write(`Tried ${portTriesLimit} ports, giving up.`);
         } else if ((e as any).code === "EADDRINUSE") {
           process.stdout.write(
@@ -102,5 +102,5 @@ export const start = async (
       });
   };
 
-  listen(startingPort);
+  listen(port);
 };


### PR DESCRIPTION
`startingPort` was being used instead of `port`. However, the default value of `port` is `startingPort`, 

```ts
export const start = async (
  port: number = startingPort,
  searchDir = process.cwd(),
) => { ... }
```

so we should use `port` to allow overriding when calling the `start` function