### PR TITLE
Remove duplicate components

### DIFF
--- a/examples/01-counter/examples/Button.example.tsx
+++ b/examples/01-counter/examples/Button.example.tsx
@@ -1,0 +1,8 @@
+import * as React from "react";
+import Button from "../src/components/Button";
+
+export default Button;
+
+export const basic = () => (
+  <Button onClick={() => alert("click!")}>Hello World</Button>
+);

--- a/examples/01-counter/src/components/Button/index.css
+++ b/examples/01-counter/src/components/Button/index.css
@@ -2,7 +2,7 @@ button {
   appearance: none;
   border: none;
   padding: 0.5rem;
-  width: 64px;
+  min-width: 64px;
   background-color: hotpink;
   font-size: 3em;
 }

--- a/examples/01-counter/src/components/Button/index.tsx
+++ b/examples/01-counter/src/components/Button/index.tsx
@@ -18,8 +18,6 @@ export default (props: Props) => (
   </button>
 );
 
-export const Button = () => <div>Test</div>;
-
 // @prodo:theme
 export const MyTheme = {
   foo: "bar",

--- a/examples/01-counter/style.css
+++ b/examples/01-counter/style.css
@@ -1,5 +1,6 @@
+/* @prodo:styles */
+
 body {
-  margin: 100px;
   font-family: sans-serif;
   text-align: center;
 }

--- a/packages/ui/src/App/context.tsx
+++ b/packages/ui/src/App/context.tsx
@@ -40,7 +40,10 @@ const findExamplesForComponent = (c: Component): Example[] => {
   }));
 };
 
-const components = userImport.components.map((c: Component) => ({
+const components = _.uniqBy(
+  userImport.components,
+  (c: Component) => c.component,
+).map((c: Component) => ({
   ...c,
   examples: findExamplesForComponent(c),
 }));


### PR DESCRIPTION
Since we are now automatically finding components, there can easily be duplicate components For example,

```ts
export const Button = () => <div />;

export default Button;
```

This was the case in the counter example. This PR removes duplicate components. It also cleans up the counter example a bit.