### PR TITLE
Remove react-dom alias and add to Parcel alias patches

### DIFF
--- a/packages/server/src/aliases.ts
+++ b/packages/server/src/aliases.ts
@@ -5,11 +5,17 @@ interface Alias {
   getNewFilename: (oldFilename: string, parent: string) => string;
 }
 
+const snoopyPackage = (name: string) => (_: string, parent: string) =>
+  path.relative(path.dirname(parent), require.resolve(name));
+
 const aliases: Alias[] = [
   {
     regex: /^styled-components$/,
-    getNewFilename: (_: string, parent: string) =>
-      path.relative(path.dirname(parent), require.resolve("styled-components")),
+    getNewFilename: snoopyPackage("styled-components"),
+  },
+  {
+    regex: /^react-dom$/,
+    getNewFilename: snoopyPackage("@hot-loader/react-dom"),
   },
 ];
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -71,8 +71,5 @@
       "\\.(gif|ttf|eot|svg|png)$": "<rootDir>/__mocks__/fileMock.js",
       "@prodo-ai/components$": "<rootDir>/__mocks__/componentsMock.ts"
     }
-  },
-  "alias": {
-    "react-dom": "@hot-loader/react-dom"
   }
 }


### PR DESCRIPTION
Using Parcel alias in `package.json` does not work when running Snoopy from a directory outside our yarn workspace because the user might not have `@hot-loader/react-dom` installed. This PR changes this so we use the relative path to the `@hot-loader/react-dom` in Snoopy.