### PR TITLE
Ignore components with @snoopy:ignore

### DIFF
--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -31,6 +31,7 @@
     "@babel/types": "^7.4.4",
     "find-up": "^4.0.0",
     "globby": "^9.2.0",
+    "lodash": "^4.17.11",
     "multimatch": "^4.0.0",
     "prettier": "^1.17.1"
   },

--- a/packages/search/src/annotations.ts
+++ b/packages/search/src/annotations.ts
@@ -8,6 +8,13 @@ const componentVisitor = mkExportVisitor({
     "The `@snoopy` tag must be directly above an exported React component.",
 });
 
+const snoopyComponentIgnoreRegex = /^\s*@snoopy:ignore\b/;
+const componentIgnoreVisitor = mkExportVisitor({
+  lineRegex: snoopyComponentIgnoreRegex,
+  invalidProdoTagError:
+    "The `@snoopy:ignore` tag must be directly above an exported React component.",
+});
+
 const snoopyThemeRegex = /^\s*@snoopy:theme\b/;
 const themeVisitor = mkExportVisitor({
   lineRegex: snoopyThemeRegex,
@@ -39,4 +46,15 @@ export const findThemeExports = (
   }
 
   return findFileExports(themeVisitor, code, filepath);
+};
+
+export const findIgnoredExports = (
+  code: string,
+  filepath: string,
+): File | null => {
+  if (!isPossibleProdoFile(code)) {
+    return null;
+  }
+
+  return findFileExports(componentIgnoreVisitor, code, filepath);
 };

--- a/packages/search/test/autodetect.test.ts
+++ b/packages/search/test/autodetect.test.ts
@@ -9,7 +9,6 @@ import Increment from "../Increment";
 
 import "./index.css";
 
-// @snoopy
 export const App = () => {
   const [count, setCount] = React.useState(0);
   return (

--- a/packages/search/test/combine.test.ts
+++ b/packages/search/test/combine.test.ts
@@ -1,0 +1,104 @@
+import {detectAndFindComponentExports} from "../src";
+
+test("doesn't duplicate exports with annotations", () => {
+  const code = `
+// @snoopy
+export const One = () => <div />;
+`;
+  const result = detectAndFindComponentExports(code, "/path/to/file.ts");
+
+  expect(result).toEqual({
+    filepath: "/path/to/file.ts",
+    fileExports: [
+      {
+        name: "One",
+        isDefaultExport: false,
+        source: "<div />;",
+      },
+    ],
+    errors: [],
+  });
+});
+
+test("doesn't duplicate default exports with annotations", () => {
+  const code = `
+const One = () => <div />;
+
+// @snoopy
+export default One;
+`;
+  const result = detectAndFindComponentExports(code, "A/path/to/file.ts");
+
+  expect(result).toEqual({
+    filepath: "A/path/to/file.ts",
+    fileExports: [
+      {
+        isDefaultExport: true,
+        source: "<div />;",
+      },
+    ],
+    errors: [],
+  });
+});
+
+test("ignores exported components with ignore annotation", () => {
+  const code = `
+export const One = () => <div />;
+
+// @snoopy
+export const Two = () => <div />;
+
+// @snoopy:ignore
+export const Three = () => <div />;
+`;
+  const result = detectAndFindComponentExports(code, "/path/to/file.ts");
+
+  expect(result).toEqual({
+    filepath: "/path/to/file.ts",
+    fileExports: [
+      {
+        name: "One",
+        isDefaultExport: false,
+        source: "<div />;",
+      },
+      {
+        name: "Two",
+        isDefaultExport: false,
+        source: "<div />;",
+      },
+    ],
+    errors: [],
+  });
+});
+
+test("ignores exported default components with ignore annotation", () => {
+  const code = `
+export const One = () => <div />;
+
+// @snoopy
+export const Two = () => <div />;
+
+const Three = () => <div />;
+
+// @snoopy:ignore
+export default Three;
+`;
+  const result = detectAndFindComponentExports(code, "/path/to/file.ts");
+
+  expect(result).toEqual({
+    filepath: "/path/to/file.ts",
+    fileExports: [
+      {
+        name: "One",
+        isDefaultExport: false,
+        source: "<div />;",
+      },
+      {
+        name: "Two",
+        isDefaultExport: false,
+        source: "<div />;",
+      },
+    ],
+    errors: [],
+  });
+});

--- a/packages/search/test/components.test.ts
+++ b/packages/search/test/components.test.ts
@@ -1,4 +1,4 @@
-import {findComponentExports} from "../src/annotations";
+import {findComponentExports, findIgnoredExports} from "../src/annotations";
 import {FileError} from "../src/types";
 
 test("gets component imports for single named export", () => {
@@ -373,6 +373,21 @@ export { Foo as One, Bar }
       {name: "One", isDefaultExport: false, source: undefined},
       {name: "Bar", isDefaultExport: false, source: undefined},
     ],
+    errors: [],
+  });
+});
+
+test("finds component imports tagged with @snoopy:ignore", () => {
+  const contents = `
+// @snoopy:ignore
+export const One = () => <div />;
+`.trim();
+
+  const componentImport = findIgnoredExports(contents, "/path/to/file.ts");
+
+  expect(componentImport).toEqual({
+    filepath: "/path/to/file.ts",
+    fileExports: [{name: "One", isDefaultExport: false, source: "<div />;"}],
     errors: [],
   });
 });

--- a/packages/ui/README.mdx
+++ b/packages/ui/README.mdx
@@ -40,6 +40,8 @@ To interact with the UI, go to [localhost:3042/][local snoopy] (or a different p
 Snoopy will detect most exported components automatically.
 If you find any that are missing, add `// @snoopy` above the export line to
 display/preview/visualize it (and let us know so we can detect it in the future).
+If you want Snoopy to ignore your component, put the `// @snoopy:ignore` tag
+above the export line.
 
 For pure components, you don't need to do anything else. If your component requires
 props to be passed in, you will need to define examples.


### PR DESCRIPTION
Allow users to use @snoopy:ignore to prevent components from showing up in the UI. I haven't created full on examples, but hopefully tests should cover it.