### PR TITLE
Search: Display errors found in the console

### DIFF
--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -176,5 +176,19 @@ export const searchCodebase = async (
     examples: getNonNullFiles(examples),
   };
 
+  displayErrorsForFiles(results.componentFiles);
+  displayErrorsForFiles(results.themeFiles);
+  displayErrorsForFiles(results.styleFiles);
+  displayErrorsForFiles(results.examples);
+
   return results;
+};
+
+const displayErrorsForFiles = (files: File[]) => {
+  for (const file of files) {
+    for (const error of file.errors) {
+      // tslint:disable-next-line:no-console
+      console.log(`Error in ${file.filepath}:`, error.message);
+    }
+  }
 };


### PR DESCRIPTION
We weren't really showing broken annotations to the user before.

Example:
<img width="814" alt="Screenshot 2019-05-28 at 11 57 09" src="https://user-images.githubusercontent.com/1416759/58473113-bddfe300-813f-11e9-9577-762def699398.png">

Edit: Maybe text should say warning instead of error, since Snoopy will still function fine?
