### PR TITLE
Add test to tsconfig for search & server

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-import {start} from "@prodo-ai/snoopy-server";
+// tslint:disable-next-line:no-submodule-imports
+import {start} from "@prodo-ai/snoopy-server/src";
 import * as yargs from "yargs";
 
 // tslint:disable-next-line:no-var-requires

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -17,7 +17,7 @@
     "start": "ts-node src/index.ts",
     "build": "tsc --build",
     "clean": "rm -rf .cache lib *.tsbuildinfo",
-    "test": "jest",
+    "test": "jest test/*",
     "lint": "set -ex; tsc --build; tslint --project ."
   },
   "dependencies": {

--- a/packages/search/test/examples.test.ts
+++ b/packages/search/test/examples.test.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
+import {examplesDirectoryName, findExampleFilePaths} from "../src/examples";
 import {findProjectRoot} from "../src/utils";
-import {findExampleFilePaths, examplesDirectoryName} from "../src/examples";
 
 const exampleDir = path.resolve(__dirname, "fixtures", "example");
 const noExamplesDir = path.resolve(__dirname, "fixures", "no-examples");

--- a/packages/search/test/fixtures/example/examples/Button.example.tsx
+++ b/packages/search/test/fixtures/example/examples/Button.example.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import Button from "../src/components/Button";
 
 export default Button;

--- a/packages/search/test/fixtures/example/package.json
+++ b/packages/search/test/fixtures/example/package.json
@@ -1,3 +1,6 @@
 {
-  "name": "example"
+  "name": "example",
+  "dependencies": {
+    "react": "^16.8.6"
+  }
 }

--- a/packages/search/test/fixtures/example/src/components/Button.tsx
+++ b/packages/search/test/fixtures/example/src/components/Button.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 
-const Button = ({children}) => <button>{children}</button>;
+const Button = ({children}: {children: React.ReactNode}) => (
+  <button>{children}</button>
+);
 
 // @snoopy
 export default Button;

--- a/packages/search/test/fixtures/example/tsconfig.json
+++ b/packages/search/test/fixtures/example/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/search/test/fixtures/no-examples/package.json
+++ b/packages/search/test/fixtures/no-examples/package.json
@@ -1,3 +1,6 @@
 {
-  "name": "example"
+  "name": "example",
+  "dependencies": {
+    "react": "^16.8.6"
+  }
 }

--- a/packages/search/test/fixtures/no-examples/src/components/Button.tsx
+++ b/packages/search/test/fixtures/no-examples/src/components/Button.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 
-const Button = ({children}) => <button>{children}</button>;
+const Button = ({children}: {children: React.ReactNode}) => (
+  <button>{children}</button>
+);
 
 // @snoopy
 export default Button;

--- a/packages/search/test/fixtures/no-examples/tsconfig.json
+++ b/packages/search/test/fixtures/no-examples/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/search/test/source.test.ts
+++ b/packages/search/test/source.test.ts
@@ -10,14 +10,13 @@ const getSource = (code: string): string | undefined => {
   }
 
   if (file.fileExports.length !== 1) {
-    console.log(file.fileExports);
     throw new Error("fileExports should have length 1.");
   }
 
   return file.fileExports[0].source;
 };
 
-const body = `{
+let body = `{
   return <div onClick={() => alert("test")} />;
 }`;
 
@@ -33,7 +32,7 @@ describe("get source from exports", () => {
   });
 
   it("should get source from named class", () => {
-    const body = `class Button extends React.Component {
+    body = `class Button extends React.Component {
   render() {
     return <div onClick={() => alert("test")} />;
   }
@@ -44,7 +43,7 @@ describe("get source from exports", () => {
   });
 
   it("should get source from default arrow", () => {
-    const body = `{
+    body = `{
   return <div onClick={() => alert("test")} />;
 }`;
     const source = getSource(`export default () => ${body}`);
@@ -62,7 +61,7 @@ describe("get source from exports", () => {
   });
 
   it("should get source from default class", () => {
-    const body = `class extends React.Component {
+    body = `class extends React.Component {
   render() {
     return <div onClick={() => alert("test")} />;
   }

--- a/packages/search/tsconfig.json
+++ b/packages/search/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "jsx": "react",
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "."
   },
-  "include": ["src", "typings"]
+  "include": ["src", "typings", "test"]
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,7 +17,7 @@
     "start": "ts-node src/index.ts",
     "build": "tsc --build",
     "clean": "rm -rf .cache lib *.tsbuildinfo",
-    "test": "jest",
+    "test": "jest test/*",
     "lint": "set -ex; tsc --build; tslint --project ."
   },
   "dependencies": {

--- a/packages/server/src/generate.ts
+++ b/packages/server/src/generate.ts
@@ -3,7 +3,7 @@ import {
   FileError,
   FileExport,
   searchCodebase,
-} from "@prodo-ai/snoopy-search";
+} from "@prodo-ai/snoopy-search/src"; // tslint:disable-line:no-submodule-imports
 import * as fs from "fs";
 import * as path from "path";
 

--- a/packages/server/src/watch.ts
+++ b/packages/server/src/watch.ts
@@ -1,4 +1,5 @@
-import {checkMatch} from "@prodo-ai/snoopy-search";
+// tslint:disable-next-line:no-submodule-imports
+import {checkMatch} from "@prodo-ai/snoopy-search/src";
 // tslint:disable-next-line:no-submodule-imports
 import {ignored} from "@prodo-ai/snoopy-search/src/utils";
 import * as chokidar from "chokidar";

--- a/packages/server/test/__snapshots__/generate.test.ts.snap
+++ b/packages/server/test/__snapshots__/generate.test.ts.snap
@@ -38,8 +38,8 @@ export const components = [
 
 export const errors = [
   {path: \\"components/BadExport.tsx\\": errors: [\\"The \`@snoopy\` tag must be directly above an exported React component.\\"]},
-  {path: \\"components/UnParsable.tsx\\": errors: [\\"Error parsing file: Unexpected token, expected \\\\\\";\\\\\\" (2:6)\\",
-  \\"Error processing file: unknown: Unexpected token, expected \\\\\\";\\\\\\" (2:6)\\\\n\\\\n\\\\u001b[0m \\\\u001b[90m 1 | \\\\u001b[39m\\\\u001b[90m// @snoopy\\\\u001b[39m\\\\u001b[0m\\\\n\\\\u001b[0m\\\\u001b[31m\\\\u001b[1m>\\\\u001b[22m\\\\u001b[39m\\\\u001b[90m 2 | \\\\u001b[39mexpor \\\\u001b[36mconst\\\\u001b[39m \\\\u001b[33mUnParsable\\\\u001b[39m () \\\\u001b[33m=>\\\\u001b[39m {}\\\\u001b[0m\\\\n\\\\u001b[0m \\\\u001b[90m   | \\\\u001b[39m      \\\\u001b[31m\\\\u001b[1m^\\\\u001b[22m\\\\u001b[39m\\\\u001b[0m\\\\n\\\\u001b[0m \\\\u001b[90m 3 | \\\\u001b[39m\\\\u001b[0m\\"]}
+  {path: \\"components/UnParsable.tsx\\": errors: [\\"Error parsing file: Unexpected token, expected \\\\\\";\\\\\\" (3:6)\\",
+  \\"Error processing file: unknown: Unexpected token, expected \\\\\\";\\\\\\" (3:6)\\\\n\\\\n\\\\u001b[0m \\\\u001b[90m 1 | \\\\u001b[39m\\\\u001b[0m\\\\n\\\\u001b[0m \\\\u001b[90m 2 | \\\\u001b[39m\\\\u001b[90m// @snoopy\\\\u001b[39m\\\\u001b[0m\\\\n\\\\u001b[0m\\\\u001b[31m\\\\u001b[1m>\\\\u001b[22m\\\\u001b[39m\\\\u001b[90m 3 | \\\\u001b[39mexpor \\\\u001b[36mconst\\\\u001b[39m \\\\u001b[33mUnParsable\\\\u001b[39m () \\\\u001b[33m=>\\\\u001b[39m {}\\\\u001b[0m\\\\n\\\\u001b[0m \\\\u001b[90m   | \\\\u001b[39m      \\\\u001b[31m\\\\u001b[1m^\\\\u001b[22m\\\\u001b[39m\\\\u001b[0m\\\\n\\\\u001b[0m \\\\u001b[90m 4 | \\\\u001b[39m\\\\u001b[0m\\"]}
 ];
 
 export const themes = [
@@ -58,7 +58,7 @@ export const styles = [
 
 export const examples = [
   {forComponent: Example0, examples: [
-    {component: Example1, title: \\"basic\\", source: \\"<NamedExport>Foo</NamedExport>;\\"}
+    {component: Example1, title: \\"basic\\", source: \\"<Button>Foo</Button>;\\"}
   ]}
 ];
 "

--- a/packages/server/test/fixtures/broken/broken.tsx
+++ b/packages/server/test/fixtures/broken/broken.tsx
@@ -1,2 +1,4 @@
+/* tslint:disable */
+
 // @snoopy
 cnst foo = () => <div>

--- a/packages/server/test/fixtures/broken/package.json
+++ b/packages/server/test/fixtures/broken/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "server fixture example",
+  "name": "server_fixture_broken",
   "dependencies": {
     "react": "^16.8.6"
   }

--- a/packages/server/test/fixtures/example/components/BadExport.tsx
+++ b/packages/server/test/fixtures/example/components/BadExport.tsx
@@ -1,3 +1,5 @@
+/* tslint:disable */
+
 // @snoopy
 export const Button = () => {};
 

--- a/packages/server/test/fixtures/example/components/UnParsable.tsx
+++ b/packages/server/test/fixtures/example/components/UnParsable.tsx
@@ -1,2 +1,3 @@
+
 // @snoopy
 expor const UnParsable () => {}

--- a/packages/server/test/fixtures/example/examples/NamedExport.example.tsx
+++ b/packages/server/test/fixtures/example/examples/NamedExport.example.tsx
@@ -3,4 +3,4 @@ import {Button} from "../components/NamedExport";
 
 export default Button;
 
-export const basic = () => <NamedExport>Foo</NamedExport>;
+export const basic = () => <Button>Foo</Button>;

--- a/packages/server/test/fixtures/example/mixed.tsx
+++ b/packages/server/test/fixtures/example/mixed.tsx
@@ -1,3 +1,5 @@
+import * as React from "react";
+
 // @snoopy
 export const Button = (props: any) => (
   <button {...props}>{props.children}</button>

--- a/packages/server/test/helpers/network.ts
+++ b/packages/server/test/helpers/network.ts
@@ -10,9 +10,9 @@ export const findFreePort = (): Promise<number> =>
       }
       const address = server.address() as net.AddressInfo;
       const port = address.port;
-      server.close((error?: Error) => {
-        if (error) {
-          reject(error);
+      server.close((err?: Error) => {
+        if (err) {
+          reject(err);
           return;
         }
         resolve(port);

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,10 +1,16 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "jsx": "react",
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "."
   },
-  "include": ["src", "typings"],
+  "include": ["src", "typings", "test"],
+  "exclude": [
+    "test/fixtures/broken/broken.tsx",
+    "test/fixtures/example/components/UnParsable.tsx",
+    "test/fixtures/example/components/BadExport.tsx"
+  ],
   "references": [
     {"path": "../api/tsconfig.json"},
     {"path": "../search/tsconfig.json"},

--- a/packages/server/typings/global.d.ts
+++ b/packages/server/typings/global.d.ts
@@ -1,0 +1,3 @@
+declare module "@babel/plugin-transform-react-jsx";
+declare module "@babel/plugin-syntax-jsx";
+declare module "@babel/plugin-transform-typescript";


### PR DESCRIPTION
Making sure tests are typechecked as well + fix the warnings and errors that were flagged.

It's a bit annoying that you currently have to import from @prodo-ai/snoopy-search/### src - I tried a couple variations of the tsconfig but didn't have time to figure that out today.

