### PR TITLE
Run from module root

### DIFF
--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -103,6 +103,12 @@ const getExportNames = (file: File) => {
     .map(x => (x as any).name);
 };
 
+export const findModuleRoot = async (cwd: string): Promise<string> => {
+  const packageRoot = await findUp("package.json", {cwd, type: "file"});
+
+  return packageRoot ? path.dirname(packageRoot) : cwd;
+};
+
 export const detectAndFindComponentExports = (
   code: string,
   filepath: string,

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -22,6 +22,7 @@ import {
 
 export * from "./types";
 export {ignored};
+export {findProjectRoot} from "./utils";
 
 export const checkMatch = async (filepath: string): Promise<boolean> => {
   const matchingFileGlob = exampleFileGlob.concat(styleFileGlob);
@@ -101,12 +102,6 @@ const getExportNames = (file: File) => {
   return file.fileExports
     .filter(x => !x.isDefaultExport)
     .map(x => (x as any).name);
-};
-
-export const findModuleRoot = async (cwd: string): Promise<string> => {
-  const packageRoot = await findUp("package.json", {cwd, type: "file"});
-
-  return packageRoot ? path.dirname(packageRoot) : cwd;
 };
 
 export const detectAndFindComponentExports = (

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,3 +1,4 @@
+import {findModuleRoot} from "@prodo-ai/snoopy-search";
 import * as Express from "express";
 import * as http from "http";
 import makeDir = require("make-dir");
@@ -36,8 +37,12 @@ const getPublicPath = async (
 
 export const start = async (
   port: number = startingPort,
-  searchDir = process.cwd(),
+  searchDirOption?: string,
 ) => {
+  const searchDir = searchDirOption || (await findModuleRoot(process.cwd()));
+
+  process.stdout.write(`Searching ${searchDir} for components...\n`);
+
   const app = Express();
 
   const snoopyComponentsModule = path.join(

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,4 @@
-import {findModuleRoot} from "@prodo-ai/snoopy-search";
+import {findProjectRoot} from "@prodo-ai/snoopy-search";
 import * as Express from "express";
 import * as http from "http";
 import makeDir = require("make-dir");
@@ -39,7 +39,8 @@ export const start = async (
   port: number = startingPort,
   searchDirOption?: string,
 ) => {
-  const searchDir = searchDirOption || (await findModuleRoot(process.cwd()));
+  const searchDir =
+    searchDirOption || (await findProjectRoot(process.cwd())) || process.cwd();
 
   process.stdout.write(`Searching ${searchDir} for components...\n`);
 


### PR DESCRIPTION
Pretty simple - just use [`find-up`](https://www.npmjs.com/package/find-up) (which was already a dependency) to locate the nearest _package.json_ file, and use that as the `searchDir` instead of `process.cwd()`.